### PR TITLE
Update SystemTest.php

### DIFF
--- a/GDO/Install/Method/SystemTest.php
+++ b/GDO/Install/Method/SystemTest.php
@@ -22,7 +22,7 @@ final class SystemTest extends Method
 			    FileUtil::createDir(GDO_PATH . 'assets'),
 				$this->testBower(),
 				function_exists('mb_strlen'),
-			    ini_get('date.timezone'),
+			    (bool) ini_get('date.timezone'),
 			    function_exists('mime_content_type'),
 			),
 			'optional' => array(


### PR DESCRIPTION
ini_get('date.timezone') returns the string value of the timezone when defined, therefore a cast to bool is needed for the test evaluation